### PR TITLE
Add Version to Manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "recteq",
   "name": "Recteq",
+  "version": "0.0.4",
   "documentation": "https://github.com/pdugas/recteq/wiki",
   "issue_tracker": "https://github.com/pdugas/recteq/issues",
   "dependencies": [],


### PR DESCRIPTION
Starting in home assistant core-2021.6 the version string is required in the manifest or the component won't start.